### PR TITLE
rom: Fix closing the ROM database

### DIFF
--- a/src/main/rom.c
+++ b/src/main/rom.c
@@ -694,6 +694,8 @@ void romdatabase_close(void)
         free(g_romdatabase.list);
         g_romdatabase.list = search;
         }
+
+    g_romdatabase.have_database = 0;
 }
 
 static romdatabase_entry* ini_search_by_md5(md5_byte_t* md5)


### PR DESCRIPTION
Otherwise we get a use after free when loading ROMs after a core shutdown + startup.